### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [12, 14, 16]
 
     steps:
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "defu": "^4.0.1",
     "esbuild": "^0.11.20",
     "execa": "^5.0.0",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
     "jiti": "^1.9.2",
-    "mkdist": "^0.1.7",
+    "mkdist": "^0.2.1",
     "rollup": "^2.47.0",
     "rollup-plugin-dts": "^3.0.1",
     "rollup-plugin-esbuild": "4.2.3",
@@ -88,7 +88,7 @@
     "eslint-plugin-promise": "^5.1.0",
     "husky": "^6.0.0",
     "jest": "^26.6.3",
-    "lint-staged": "^10.5.4",
+    "lint-staged": "^11.0.0",
     "pinst": "^2.1.6",
     "prettier": "^2.3.0",
     "release-it": "14.6.2",
@@ -96,6 +96,6 @@
     "typescript": "^4.2.4"
   },
   "volta": {
-    "node": "10.24.0"
+    "node": "12.22.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3240,10 +3240,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^6.2.0":
-  version: 6.2.1
-  resolution: "commander@npm:6.2.1"
-  checksum: 47856aae6f194404122e359d8463e5e1a18f7cbab26722ce69f1379be8514bd49a160ef81a983d3d2091e3240022643354101d1276c797dcdd0b5bfc3c3f04a3
+"commander@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: bdc0eca5e25cd24af8440163d3c9a996785bbac4b49a590365699cdc1ed08cefbac8f268153208ab2bc5dc3cb1d3fb573fd1590c681e36e371342186bd331a4c
   languageName: node
   linkType: hard
 
@@ -3667,7 +3667,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.2.0":
+"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1":
   version: 4.3.2
   resolution: "debug@npm:4.3.2"
   dependencies:
@@ -4317,7 +4317,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^4.0.0, execa@npm:^4.0.2, execa@npm:^4.1.0":
+"execa@npm:^4.0.0, execa@npm:^4.0.2":
   version: 4.1.0
   resolution: "execa@npm:4.1.0"
   dependencies:
@@ -4650,6 +4650,17 @@ __metadata:
   version: 1.3.2
   resolution: "fromentries@npm:1.3.2"
   checksum: 5cc722e4e3fd333ba75f31dd3ef80b4a6c405d8814e86e343b4676c1483c00f4f29b39aca462d268e918b3316a4fb03cea8022458fd8ad965f251362a129783f
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "fs-extra@npm:10.0.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 84632d143fe3125b8c3c2b1fedbbdfcfb84fc3e087522b4e138cc07edf574619925713a6609f6d5e53ede2e31ab319c7d528ea4a4a770ba6622a16bf4447cd8b
   languageName: node
   linkType: hard
 
@@ -6669,32 +6680,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lint-staged@npm:^10.5.4":
-  version: 10.5.4
-  resolution: "lint-staged@npm:10.5.4"
+"lint-staged@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "lint-staged@npm:11.0.0"
   dependencies:
-    chalk: ^4.1.0
+    chalk: ^4.1.1
     cli-truncate: ^2.1.0
-    commander: ^6.2.0
+    commander: ^7.2.0
     cosmiconfig: ^7.0.0
-    debug: ^4.2.0
+    debug: ^4.3.1
     dedent: ^0.7.0
     enquirer: ^2.3.6
-    execa: ^4.1.0
-    listr2: ^3.2.2
-    log-symbols: ^4.0.0
-    micromatch: ^4.0.2
+    execa: ^5.0.0
+    listr2: ^3.8.2
+    log-symbols: ^4.1.0
+    micromatch: ^4.0.4
     normalize-path: ^3.0.0
     please-upgrade-node: ^3.2.0
     string-argv: 0.3.1
     stringify-object: ^3.3.0
   bin:
     lint-staged: bin/lint-staged.js
-  checksum: dbcafe3679668379fc03f3aef481c3f710794ec03dd5c3915f26a0de110977fbcb44b55ab6dfcff9e8e5789c568ea5629e92f55944fc43f6f6fa1890ee5b07ba
+  checksum: e5d9c38f468fae090939d150f8a1676ca208e50c714f20c9957a16833eeae20ca9676c8679883d0a005fda58375581c26352e18a2227d6449a29adaca650f957
   languageName: node
   linkType: hard
 
-"listr2@npm:^3.2.2":
+"listr2@npm:^3.8.2":
   version: 3.8.2
   resolution: "listr2@npm:3.8.2"
   dependencies:
@@ -6794,7 +6805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
+"log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
   dependencies:
@@ -6985,7 +6996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "micromatch@npm:4.0.4"
   dependencies:
@@ -7104,9 +7115,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdist@npm:^0.1.7":
-  version: 0.1.7
-  resolution: "mkdist@npm:0.1.7"
+"mkdist@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "mkdist@npm:0.2.1"
   dependencies:
     defu: ^3.2.2
     esbuild: ^0.11.6
@@ -7123,7 +7134,7 @@ __metadata:
       optional: true
   bin:
     mkdist: dist/cli.js
-  checksum: 503703fbc27a18e123f16ae770645c22a11f0c1fe5149f7e8ebdd7744e07bacbc1439c3db83d6110d372c4599b3f13edd14fc2f7c8a3f185bf900d24174fa03d
+  checksum: f0b852e3aa7e8f482ccc03f5af9feb1d43de1662e197e4f08259fc66a8df6a7a8df7a816e71580f4c6463fc40773dd800cfb88770de9ce702539134995e0a737
   languageName: node
   linkType: hard
 
@@ -8854,13 +8865,13 @@ __metadata:
     eslint-plugin-prettier: ^3.4.0
     eslint-plugin-promise: ^5.1.0
     execa: ^5.0.0
-    fs-extra: ^9.1.0
+    fs-extra: ^10.0.0
     glob: ^7.1.7
     husky: ^6.0.0
     jest: ^26.6.3
     jiti: ^1.9.2
-    lint-staged: ^10.5.4
-    mkdist: ^0.1.7
+    lint-staged: ^11.0.0
+    mkdist: ^0.2.1
     pinst: ^2.1.6
     prettier: ^2.3.0
     release-it: 14.6.2


### PR DESCRIPTION
BREAKING CHANGE: Requires Node 12+
BREAKING CHANGE: produces .mjs in subpath exports

* See mkdist CHANGELOG for full details of .mjs breaking change https://github.com/unjs/mkdist/blob/main/CHANGELOG.md#020-2021-04-21