### PR TITLE
fix!: use regexps to match dependency externals

### DIFF
--- a/src/core/build/rollup.spec.ts
+++ b/src/core/build/rollup.spec.ts
@@ -71,15 +71,26 @@ describe('builtins', () => {
 
 describe('external matching', () => {
   const pattern = regexpForPackage('@nuxt/utils')
+
   it('should match package name', () => {
     expect(pattern.test('@nuxt/utils')).toBeTruthy()
   })
+
   it('should match package subpath', () => {
     expect(pattern.test('@nuxt/utils/subpath')).toBeTruthy()
   })
+
   it('should match fully resolved package path', () => {
     expect(
-      pattern.test('/home/me/project/node_modules/@nuxt/utils/index.js')
+      pattern.test('/project/node_modules/@nuxt/utils/index.js')
     ).toBeTruthy()
+    expect(
+      pattern.test('c:\\project\\node_modules\\@nuxt\\utils\\index.js')
+    ).toBeTruthy()
+  })
+
+  it('should not match substring paths', () => {
+    expect(pattern.test('@nuxt/utils2')).toBeFalsy()
+    expect(pattern.test('a@nuxt/utils')).toBeFalsy()
   })
 })

--- a/src/core/build/rollup.spec.ts
+++ b/src/core/build/rollup.spec.ts
@@ -2,7 +2,7 @@ import { resolve } from 'upath'
 
 import { Package } from '../package'
 import { builtins, builtinsMap } from './builtins'
-import { getRollupConfig } from './rollup'
+import { getRollupConfig, regexpForPackage } from './rollup'
 import { getNameFunction } from './utils'
 
 const getFixturePath = (path: string) =>
@@ -66,5 +66,20 @@ describe('builtins', () => {
     const newMap = builtinsMap()
     expect(map).toBe(newMap)
     expect(Object.values(map)[0]).toBe(true)
+  })
+})
+
+describe('external matching', () => {
+  const pattern = regexpForPackage('@nuxt/utils')
+  it('should match package name', () => {
+    expect(pattern.test('@nuxt/utils')).toBeTruthy()
+  })
+  it('should match package subpath', () => {
+    expect(pattern.test('@nuxt/utils/subpath')).toBeTruthy()
+  })
+  it('should match fully resolved package path', () => {
+    expect(
+      pattern.test('/home/me/project/node_modules/@nuxt/utils/index.js')
+    ).toBeTruthy()
   })
 })

--- a/src/core/build/rollup.ts
+++ b/src/core/build/rollup.ts
@@ -41,9 +41,10 @@ export interface BuildOverride {
 }
 
 export function regexpForPackage(name: string) {
-  // Should match `@foo/bar/index.js`, `node_modules/@foo/bar` as well as
-  // `@foo/bar`.
-  return new RegExp(`(^|node_modules[\\/])${name}([\\/]|$)`, 'i')
+  // Should match `@foo/bar/index.js`, `node_modules\@foo\bar`,
+  // `node_modules/@foo/bar` as well as `@foo/bar`.
+  name = name.replace(/[\\/]/g, '[\\\\/]')
+  return new RegExp(`(^|node_modules[\\\\/])${name}([\\\\/]|$)`, 'i')
 }
 
 function regexpForPackages(packages?: Record<string, string>) {

--- a/src/core/build/rollup.ts
+++ b/src/core/build/rollup.ts
@@ -40,6 +40,16 @@ export interface BuildOverride {
   format: OutputOptions['format']
 }
 
+export function regexpForPackage(name: string) {
+  // Should match `@foo/bar/index.js`, `node_modules/@foo/bar` as well as
+  // `@foo/bar`.
+  return new RegExp(`(^|node_modules[\\/])${name}([\\/]|$)`, 'i')
+}
+
+function regexpForPackages(packages?: Record<string, string>) {
+  return Object.keys(packages || {}).map(regexpForPackage)
+}
+
 export function getRollupConfig(
   {
     input,
@@ -74,9 +84,9 @@ export function getRollupConfig(
 
   const external = [
     // Dependencies that will be installed alongside the package
-    ...Object.keys(pkgConfig.dependencies || {}),
-    ...Object.keys(pkgConfig.optionalDependencies || {}),
-    ...Object.keys(pkgConfig.peerDependencies || {}),
+    ...regexpForPackages(pkgConfig.dependencies),
+    ...regexpForPackages(pkgConfig.optionalDependencies),
+    ...regexpForPackages(pkgConfig.peerDependencies),
     // Builtin node modules
     ...builtins,
     ...externals,


### PR DESCRIPTION
* avoids inlining subpaths or fully resolved paths

Context (for example): https://github.com/nuxt/test-utils/issues/140
cc: @pi0 