### PR TITLE
fix(core): generate .d.ts files for .mjs exports

### DIFF
--- a/src/core/build/rollup.ts
+++ b/src/core/build/rollup.ts
@@ -232,7 +232,7 @@ export function getRollupConfig(
         defu({}, options as RollupOptions, {
           input: pkg.resolveEntrypoint(outfile),
           output: {
-            file: resolvePath(outfile.replace(/(\.es)?\.js$/, '.d.ts')),
+            file: resolvePath(outfile.replace(/(\.es)?\.m?js$/, '.d.ts')),
             format: 'es',
             exports: 'auto',
           } as OutputOptions,


### PR DESCRIPTION
This PR adds support for generating .d.ts files for .mjs exports.

Without this PR, only .js and .es.js exports generated .d.ts files.
